### PR TITLE
Improved Juju::Is-JujuMasterUnit logic

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+###version 0.11
+  - 06.04.2015
+  - Improved ``Juju::Is-JujuMasterUnit`` logic.
+    - If ``$PeerRelationName`` parameter is given, the first peer is considered the master unit.
+
 ###version 0.10
   - 30.03.2015
   - First commit.


### PR DESCRIPTION
If $PeerRelationName parameter is given, the first peer is considered the master unit
