### PR TITLE
Update Templating and powershell-yaml modules

### DIFF
--- a/Templating/Load-Assemblies.ps1
+++ b/Templating/Load-Assemblies.ps1
@@ -14,52 +14,22 @@
 #
 
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
-$libDir = Join-Path $here "lib"
-
-function ServerLevelKey {
-    <#
-    .SYNOPSIS
-    Returns the path to the registry location where information about the server levels is stored
-    #>
-    PROCESS {
-        return "HKLM:Software\Microsoft\Windows NT\CurrentVersion\Server\ServerLevels"
-    }
-}
-
-function IsNanoServer {
-    <#
-    .SYNOPSIS
-    Return a boolean value of $true if we are running on a Nano server version.
-    #>
-    PROCESS {
-        $serverLevelKey = ServerLevelKey
-        if (!(Test-Path $serverLevelKey)){
-            # We are most likely running on a workstation version
-            return $false
-        }
-        $serverLevels = Get-ItemProperty $serverLevelKey
-        return ($serverLevels.NanoServer -eq 1)
-    }
-}
 
 function Initialize-Assemblies {
-    $isNano = IsNanoServer
-    $assemblyDir = Join-Path $libDir "net35"
-    if($isNano){
-        # Load the portable assembly
-        $assemblyDir = Join-Path $libDir "netcore50"
+    $libDir = Join-Path $here "lib"
+    $assemblies = @{
+        "portable" = Join-Path $libDir "netcore50\DotLiquid.dll";
+        "released" = Join-Path $libDir "net35\DotLiquid.dll";
     }
-    $assemblyFile = Join-Path $assemblyDir "DotLiquid.dll"
+
     try {
         [DotLiquid.Template] | Out-Null
     } catch [System.Management.Automation.RuntimeException] {
-        if(!(Test-Path $assemblyFile)) {
-            Throw "Could not find DotLiquid assembly on the system"
+        try {
+            return [Microsoft.PowerShell.CoreCLR.AssemblyExtensions]::LoadFrom($assemblies["portable"])
+        } catch [System.Management.Automation.RuntimeException] {
+            return [Reflection.Assembly]::LoadFrom($assemblies["released"])
         }
-        if($isNano){
-            return [Microsoft.PowerShell.CoreCLR.AssemblyExtensions]::LoadFrom($assemblyFile)
-        }
-        return [Reflection.Assembly]::LoadFrom($assemblyFile)
     }
 }
 


### PR DESCRIPTION
This Pr updates powershell-yaml to it's latest version. It also updates the Templating module to allow contexts that are not generic .Net objects. DotLiquid will not properly parse a powershell object. The templating module now converts powershell objects to Generic Dictionaries and Lists.