### PR TITLE
Fixed 'Add-WindowsUser' when creating a user with a long password

### DIFF
--- a/JujuWindowsUtils/JujuWindowsUtils.psm1
+++ b/JujuWindowsUtils/JujuWindowsUtils.psm1
@@ -791,7 +791,7 @@ function Add-WindowsUser {
         }
         $cmd = @("net.exe", "user", $Username)
         if (!$exists) {
-            $cmd += @($Password, "/add", "/expires:never", "/active:yes")
+            $cmd += @($Password, "/add", "/expires:never", "/active:yes", "/Y")
             if($Fullname) {
                 $cmd += "/fullname:{0}" -f @($Fullname)
             }

--- a/JujuWindowsUtils/Tests/JujuWindowsUtils.Tests.ps1
+++ b/JujuWindowsUtils/Tests/JujuWindowsUtils.Tests.ps1
@@ -220,7 +220,7 @@ Describe "Test Add-WindowsUser" {
                 (Compare-Object $Command @("net.exe", "user", $fakeUser, $fakePassword,
                                            "/add", ("/fullname:{0}" -f @($fakeFullname)),
                                            ("/comment:{0}" -f @($fakeDescription)),
-                                           "/expires:never", "/active:yes")) -eq $null
+                                           "/expires:never", "/active:yes", "/Y")) -eq $null
             }
         }
     }
@@ -234,7 +234,7 @@ Describe "Test Add-WindowsUser" {
             Assert-MockCalled Invoke-JujuCommand -ModuleName JujuWindowsUtils -Exactly 1 -ParameterFilter {
                 (Compare-Object $Command @("net.exe", "user", $fakeUser, $fakePassword,
                                            "/add", ("/comment:{0}" -f @($fakeDescription)),
-                                           "/expires:never", "/active:yes")) -eq $null
+                                           "/expires:never", "/active:yes", "/Y")) -eq $null
             }
         }
     }
@@ -248,7 +248,7 @@ Describe "Test Add-WindowsUser" {
             Assert-MockCalled Invoke-JujuCommand -ModuleName JujuWindowsUtils -Exactly 1 -ParameterFilter {
                 (Compare-Object $Command @("net.exe", "user", $fakeUser, $fakePassword,
                                            "/add", ("/fullname:{0}" -f @($fakeFullname)),
-                                           "/expires:never", "/active:yes")) -eq $null
+                                           "/expires:never", "/active:yes", "/Y")) -eq $null
             }
         }
     }
@@ -261,7 +261,7 @@ Describe "Test Add-WindowsUser" {
             Assert-MockCalled Get-AccountObjectByName -ModuleName JujuWindowsUtils -Exactly 1
             Assert-MockCalled Invoke-JujuCommand -ModuleName JujuWindowsUtils -Exactly 1 -ParameterFilter {
                 (Compare-Object $Command @("net.exe", "user", $fakeUser, $fakePassword,
-                                           "/add", "/expires:never", "/active:yes")) -eq $null
+                                           "/add", "/expires:never", "/active:yes", "/Y")) -eq $null
             }
         }
     }


### PR DESCRIPTION
When creating a user with 'net.exe' with a password longer than 14 characters, a warning message appears specifying that the user cannot be logged from versions of Windows prior to Windows 2000.

Those versions of Windows are not supported in Juju charms. Added `/Y` to suppress the warning message and allow command completion.